### PR TITLE
Support django 1.10

### DIFF
--- a/dartcms/apps/pages/migrations/0001_initial.py
+++ b/dartcms/apps/pages/migrations/0001_initial.py
@@ -55,7 +55,7 @@ class Migration(migrations.Migration):
                 'verbose_name_plural': 'pages',
             },
             managers=[
-                ('object', django.db.models.manager.Manager()),
+                ('objects', django.db.models.manager.Manager()),
             ],
         ),
         migrations.CreateModel(

--- a/dartcms/apps/pages/migrations/0001_initial.py
+++ b/dartcms/apps/pages/migrations/0001_initial.py
@@ -55,7 +55,7 @@ class Migration(migrations.Migration):
                 'verbose_name_plural': 'pages',
             },
             managers=[
-                ('_default_manager', django.db.models.manager.Manager()),
+                ('object', django.db.models.manager.Manager()),
             ],
         ),
         migrations.CreateModel(


### PR DESCRIPTION
При апгрейде до 10-й джанги не проходила 1-я миграция модуля pages. Эта ошибка вызвана несовместимостью mptt с django 1.10. [Здесь](https://github.com/django-mptt/django-mptt/issues/469) описана проблема и её решение.